### PR TITLE
add wsaccel and orjson

### DIFF
--- a/ks_includes/KlippyWebsocket.py
+++ b/ks_includes/KlippyWebsocket.py
@@ -1,7 +1,10 @@
 #!/usr/bin/python
 
 import threading
+# Start FLSUN Changes
+#import json
 import orjson
+# End FLSUN Changes
 import logging
 
 import gi
@@ -71,7 +74,10 @@ class KlippyWebsocket(threading.Thread):
             on_open=self.on_open,
             header=self.header
         )
+        # Start FLSUN Changes
+        #self._wst = threading.Thread(target=self.ws.run_forever, daemon=True)
         self._wst = threading.Thread(target=self.ws.run_forever, kwargs={'skip_utf8_validation': True}, daemon=True)
+        # End FLSUN Changes
         try:
             logging.debug("Starting websocket thread")
             self._wst.start()
@@ -90,7 +96,10 @@ class KlippyWebsocket(threading.Thread):
 
     def on_message(self, *args):
         message = args[1] if len(args) == 2 else args[0]
+        # Start FLSUN Changes
+        #response = json.loads(message)
         response = orjson.loads(message)
+        # End FLSUN Changes
         if "id" in response and response['id'] in self.callback_table:
             args = (response,
                     self.callback_table[response['id']][1],
@@ -124,7 +133,10 @@ class KlippyWebsocket(threading.Thread):
             "params": params,
             "id": self._req_id
         }
+        # Start FLSUN Changes
+        #self.ws.send(json.dumps(data))
         self.ws.send(orjson.dumps(data))
+        # End FLSUN Changes
         return True
 
     def on_open(self, *args):

--- a/ks_includes/KlippyWebsocket.py
+++ b/ks_includes/KlippyWebsocket.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import threading
-import json
+import orjson
 import logging
 
 import gi
@@ -71,7 +71,7 @@ class KlippyWebsocket(threading.Thread):
             on_open=self.on_open,
             header=self.header
         )
-        self._wst = threading.Thread(target=self.ws.run_forever, daemon=True)
+        self._wst = threading.Thread(target=self.ws.run_forever, kwargs={'skip_utf8_validation': True}, daemon=True)
         try:
             logging.debug("Starting websocket thread")
             self._wst.start()
@@ -90,7 +90,7 @@ class KlippyWebsocket(threading.Thread):
 
     def on_message(self, *args):
         message = args[1] if len(args) == 2 else args[0]
-        response = json.loads(message)
+        response = orjson.loads(message)
         if "id" in response and response['id'] in self.callback_table:
             args = (response,
                     self.callback_table[response['id']][1],
@@ -124,7 +124,7 @@ class KlippyWebsocket(threading.Thread):
             "params": params,
             "id": self._req_id
         }
-        self.ws.send(json.dumps(data))
+        self.ws.send(orjson.dumps(data))
         return True
 
     def on_open(self, *args):

--- a/scripts/KlipperScreen-requirements.txt
+++ b/scripts/KlipperScreen-requirements.txt
@@ -13,6 +13,8 @@ PyGObject==3.48.1;python_version>="3.8"
 pycairo==1.26.1;python_version>="3.8"
 websocket-client==1.8.0;python_version>="3.8"
 
-wsaccel==0.6.6 ; python_version>='3.9'
-wsaccel==0.6.4 ; python_version<='3.8'
+# Start FLSUN Changes
+wsaccel==0.6.6;python_version>='3.9'
+wsaccel==0.6.4;python_version<='3.8'
 orjson==3.10.7
+# End FLSUN Changes

--- a/scripts/KlipperScreen-requirements.txt
+++ b/scripts/KlipperScreen-requirements.txt
@@ -12,3 +12,7 @@ backports.zoneinfo;python_version<"3.9"
 PyGObject==3.48.1;python_version>="3.8"
 pycairo==1.26.1;python_version>="3.8"
 websocket-client==1.8.0;python_version>="3.8"
+
+wsaccel==0.6.6 ; python_version>='3.9'
+wsaccel==0.6.4 ; python_version<='3.8'
+orjson==3.10.7


### PR DESCRIPTION
Added `wsaccel` dependency to speed up websocket and disabled utf8 validation, which greatly affects performance.
Replaced the json parsing library in websocket processing
These changes lead to a 3-7% decrease in CPU load